### PR TITLE
feat: 支持第三方游戏下载源并新增链接连通性检测

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -19,6 +19,7 @@
 ## 开发人员
 
     神麤詭末 <https://github.com/scgm0>
+    寒士杰克 <https://github.com/TGU-HansJack>
 
 ## 英语翻译
 

--- a/MVL/Src/UI/Page/ReleasePage.cs
+++ b/MVL/Src/UI/Page/ReleasePage.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Godot;
@@ -10,6 +11,8 @@ using MVL.Utils.Help;
 namespace MVL.UI.Page;
 
 public partial class ReleasePage : MenuPage {
+	private const string OfficialReleaseListUrl = "https://api.vintagestory.at/stable-unstable.json";
+
 	[Export]
 	private PackedScene? _gameDownloadScene;
 
@@ -68,7 +71,15 @@ public partial class ReleasePage : MenuPage {
 		var downloadWindow = _gameDownloadScene!.Instantiate<GameDownloadWindow>();
 		UI.Main.Instance?.AddChild(downloadWindow);
 		await downloadWindow.Show();
-		downloadWindow.UpdateDownloadList("https://api.vintagestory.at/stable-unstable.json");
+		var releaseListUrl = OfficialReleaseListUrl;
+		if (UI.Main.BaseConfig.UseThirdPartyGameDownload) {
+			var customReleaseListUrl = UI.Main.BaseConfig.ThirdPartyGameLink.Trim();
+			if (!string.IsNullOrWhiteSpace(customReleaseListUrl)) {
+				releaseListUrl = customReleaseListUrl;
+			}
+		}
+
+		downloadWindow.UpdateDownloadList(releaseListUrl);
 		downloadWindow.InstallGame += ImportGame;
 		downloadWindow.Hidden += downloadWindow.QueueFree;
 	}

--- a/MVL/Src/UI/Page/SettingPage.cs
+++ b/MVL/Src/UI/Page/SettingPage.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using Flurl.Http;
 using Godot;
 using MVL.UI.Window;
@@ -36,6 +37,15 @@ public partial class SettingPage : MenuPage {
 
 	[Export]
 	private LineEdit? _proxyAddressLineEdit;
+
+	[Export]
+	private CheckButton? _useThirdPartyGameDownloadCheckButton;
+
+	[Export]
+	private LineEdit? _thirdPartyGameLinkLineEdit;
+
+	[Export]
+	private Button? _thirdPartyGameLinkCheckButton;
 
 	[Export]
 	private SpinBox? _downloadThreadSpinbox;
@@ -101,6 +111,9 @@ public partial class SettingPage : MenuPage {
 		_renderingDriverOptionButton.NotNull();
 		_menuExpandCheckButton.NotNull();
 		_proxyAddressLineEdit.NotNull();
+		_useThirdPartyGameDownloadCheckButton.NotNull();
+		_thirdPartyGameLinkLineEdit.NotNull();
+		_thirdPartyGameLinkCheckButton.NotNull();
 		_downloadThreadSpinbox.NotNull();
 		_modpackFolderLineEdit.NotNull();
 		_modpackFolderButton.NotNull();
@@ -115,6 +128,10 @@ public partial class SettingPage : MenuPage {
 		_displayScaleSpinbox.Value = UI.Main.BaseConfig.DisplayScale * 100;
 		_menuExpandCheckButton.ButtonPressed = UI.Main.BaseConfig.MenuExpand;
 		_proxyAddressLineEdit.Text = UI.Main.BaseConfig.ProxyAddress;
+		_useThirdPartyGameDownloadCheckButton.ButtonPressed = UI.Main.BaseConfig.UseThirdPartyGameDownload;
+		_thirdPartyGameLinkLineEdit.Text = UI.Main.BaseConfig.ThirdPartyGameLink;
+		_thirdPartyGameLinkLineEdit.Editable = _useThirdPartyGameDownloadCheckButton.ButtonPressed;
+		UpdateThirdPartyGameLinkCheckButtonState();
 		_downloadThreadSpinbox.Value = UI.Main.BaseConfig.DownloadThreads;
 		_modpackFolderLineEdit.Text = UI.Main.BaseConfig.ModpackFolder;
 		_releaseFolderLineEdit.Text = UI.Main.BaseConfig.ReleaseFolder;
@@ -125,6 +142,10 @@ public partial class SettingPage : MenuPage {
 		_renderingDriverOptionButton.ItemSelected += RenderingDriverOptionButtonOnItemSelected;
 		_menuExpandCheckButton.Toggled += MenuExpandCheckButtonOnToggled;
 		_proxyAddressLineEdit.EditingToggled += ProxyAddressLineEditOnEditingToggled;
+		_useThirdPartyGameDownloadCheckButton.Toggled += UseThirdPartyGameDownloadCheckButtonOnToggled;
+		_thirdPartyGameLinkLineEdit.EditingToggled += ThirdPartyGameLinkLineEditOnEditingToggled;
+		_thirdPartyGameLinkLineEdit.TextChanged += ThirdPartyGameLinkLineEditOnTextChanged;
+		_thirdPartyGameLinkCheckButton.Pressed += ThirdPartyGameLinkCheckButtonOnPressed;
 		_downloadThreadSpinbox.ValueChanged += DownloadThreadSpinboxOnValueChanged;
 		_modpackFolderLineEdit.EditingToggled += ModpackFolderLineEditOnEditingToggled;
 		_releaseFolderLineEdit.EditingToggled += ReleaseFolderLineEditOnEditingToggled;
@@ -264,6 +285,71 @@ public partial class SettingPage : MenuPage {
 		UI.Main.BaseConfig.ProxyAddress = _proxyAddressLineEdit!.Text;
 		FlurlHttp.Clients.Clear();
 		UI.Main.BaseConfig.Save();
+	}
+
+	private void UseThirdPartyGameDownloadCheckButtonOnToggled(bool toggledOn) {
+		UI.Main.BaseConfig.UseThirdPartyGameDownload = toggledOn;
+		_thirdPartyGameLinkLineEdit!.Editable = toggledOn;
+		UpdateThirdPartyGameLinkCheckButtonState();
+		UI.Main.BaseConfig.Save();
+	}
+
+	private void ThirdPartyGameLinkLineEditOnEditingToggled(bool toggledOn) {
+		if (toggledOn) {
+			return;
+		}
+
+		UI.Main.BaseConfig.ThirdPartyGameLink = _thirdPartyGameLinkLineEdit!.Text.Trim();
+		UI.Main.BaseConfig.Save();
+	}
+
+	private void ThirdPartyGameLinkLineEditOnTextChanged(string _) { UpdateThirdPartyGameLinkCheckButtonState(); }
+
+	private void UpdateThirdPartyGameLinkCheckButtonState() {
+		_thirdPartyGameLinkCheckButton!.Disabled = !_useThirdPartyGameDownloadCheckButton!.ButtonPressed ||
+		                                           string.IsNullOrWhiteSpace(_thirdPartyGameLinkLineEdit!.Text);
+	}
+
+	private void ShowThirdPartyGameLinkCheckResult(string message) {
+		var confirmationWindow = _confirmationWindowScene!.Instantiate<ConfirmationWindow>();
+		confirmationWindow.Message = message;
+		confirmationWindow.Hidden += confirmationWindow.QueueFree;
+		confirmationWindow.Confirm += async () => { await confirmationWindow.Hide(); };
+		UI.Main.Instance?.AddChild(confirmationWindow);
+		_ = confirmationWindow.Show();
+	}
+
+	private async void ThirdPartyGameLinkCheckButtonOnPressed() {
+		var url = _thirdPartyGameLinkLineEdit!.Text.Trim();
+
+		if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) ||
+		    (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)) {
+			ShowThirdPartyGameLinkCheckResult("链接格式无效，请输入 http 或 https 链接");
+			return;
+		}
+
+		var originalText = _thirdPartyGameLinkCheckButton!.Text;
+		_thirdPartyGameLinkCheckButton.Text = "检测中...";
+		_thirdPartyGameLinkCheckButton.Disabled = true;
+
+		try {
+			await using var stream = await url.WithTimeout(10).GetStreamAsync();
+			var releases = await JsonSerializer.DeserializeAsync(
+				stream,
+				SourceGenerationContext.Default.DictionaryGameVersionGameRelease
+			);
+			if (releases == null || releases.Count == 0) {
+				throw new InvalidDataException("返回内容可解析，但版本列表为空");
+			}
+
+			ShowThirdPartyGameLinkCheckResult("检测成功，链接可访问且返回了有效 JSON");
+		} catch (Exception e) {
+			Log.Error("检测第三方游戏链接失败", e);
+			ShowThirdPartyGameLinkCheckResult($"检测失败：{e.Message}");
+		} finally {
+			_thirdPartyGameLinkCheckButton.Text = originalText;
+			UpdateThirdPartyGameLinkCheckButtonState();
+		}
 	}
 
 	private void DisplayScaleSpinboxOnValueChanged(double value) {

--- a/MVL/Src/UI/Page/setting_page.tscn
+++ b/MVL/Src/UI/Page/setting_page.tscn
@@ -37,7 +37,7 @@ IconName = "reload"
 IconSize = 18
 metadata/_custom_type_script = "uid://bk3tot6c35bwu"
 
-[node name="SettingPage" type="Control" unique_id=718450851 node_paths=PackedStringArray("_displayLanguageOptionButton", "_displayScaleSpinbox", "_renderingDriverOptionButton", "_menuExpandCheckButton", "_proxyAddressLineEdit", "_downloadThreadSpinbox", "_modpackFolderLineEdit", "_modpackFolderButton", "_releaseFolderLineEdit", "_releaseFolderButton", "_localTranslationFolderLabel", "_localTranslationReloadButton", "_gitHubProxyOptionButton", "_autoCheckVersionCheckButton", "_lastVersionLinkButton", "Main")]
+[node name="SettingPage" type="Control" unique_id=718450851 node_paths=PackedStringArray("_displayLanguageOptionButton", "_displayScaleSpinbox", "_renderingDriverOptionButton", "_menuExpandCheckButton", "_proxyAddressLineEdit", "_useThirdPartyGameDownloadCheckButton", "_thirdPartyGameLinkLineEdit", "_thirdPartyGameLinkCheckButton", "_downloadThreadSpinbox", "_modpackFolderLineEdit", "_modpackFolderButton", "_releaseFolderLineEdit", "_releaseFolderButton", "_localTranslationFolderLabel", "_localTranslationReloadButton", "_gitHubProxyOptionButton", "_autoCheckVersionCheckButton", "_lastVersionLinkButton", "Main")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -54,6 +54,9 @@ _displayScaleSpinbox = NodePath("MarginContainer/ScrollContainer/VBoxContainer/P
 _renderingDriverOptionButton = NodePath("MarginContainer/ScrollContainer/VBoxContainer/PanelContainer/VBoxContainer/MarginContainer/VBoxContainer/HBoxContainer3/OptionButton")
 _menuExpandCheckButton = NodePath("MarginContainer/ScrollContainer/VBoxContainer/PanelContainer/VBoxContainer/MarginContainer/VBoxContainer/HBoxContainer4/CheckButton")
 _proxyAddressLineEdit = NodePath("MarginContainer/ScrollContainer/VBoxContainer/PanelContainer2/VBoxContainer/MarginContainer/VBoxContainer/HBoxContainer/LineEdit")
+_useThirdPartyGameDownloadCheckButton = NodePath("MarginContainer/ScrollContainer/VBoxContainer/PanelContainer2/VBoxContainer/MarginContainer/VBoxContainer/HBoxContainer3/CheckButton")
+_thirdPartyGameLinkLineEdit = NodePath("MarginContainer/ScrollContainer/VBoxContainer/PanelContainer2/VBoxContainer/MarginContainer/VBoxContainer/HBoxContainer4/LineEdit")
+_thirdPartyGameLinkCheckButton = NodePath("MarginContainer/ScrollContainer/VBoxContainer/PanelContainer2/VBoxContainer/MarginContainer/VBoxContainer/HBoxContainer4/Button")
 _downloadThreadSpinbox = NodePath("MarginContainer/ScrollContainer/VBoxContainer/PanelContainer2/VBoxContainer/MarginContainer/VBoxContainer/HBoxContainer2/SpinBox")
 _modpackFolderLineEdit = NodePath("MarginContainer/ScrollContainer/VBoxContainer/PanelContainer3/VBoxContainer/MarginContainer/VBoxContainer/HBoxContainer/LineEdit")
 _modpackFolderButton = NodePath("MarginContainer/ScrollContainer/VBoxContainer/PanelContainer3/VBoxContainer/MarginContainer/VBoxContainer/HBoxContainer/Button")
@@ -250,6 +253,44 @@ max_value = 64.0
 value = 1.0
 alignment = 2
 suffix = "x"
+
+[node name="HBoxContainer3" type="HBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/PanelContainer2/VBoxContainer/MarginContainer/VBoxContainer" unique_id=1535837021]
+custom_minimum_size = Vector2(0, 32)
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/ScrollContainer/VBoxContainer/PanelContainer2/VBoxContainer/MarginContainer/VBoxContainer/HBoxContainer3" unique_id=678139254]
+layout_mode = 2
+mouse_filter = 1
+text = "第三方游戏下载"
+
+[node name="CheckButton" type="CheckButton" parent="MarginContainer/ScrollContainer/VBoxContainer/PanelContainer2/VBoxContainer/MarginContainer/VBoxContainer/HBoxContainer3" unique_id=1470846118]
+layout_mode = 2
+size_flags_horizontal = 10
+theme_override_font_sizes/font_size = 14
+text = "使用第三方游戏下载"
+
+[node name="HBoxContainer4" type="HBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/PanelContainer2/VBoxContainer/MarginContainer/VBoxContainer" unique_id=425545369]
+custom_minimum_size = Vector2(0, 32)
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/ScrollContainer/VBoxContainer/PanelContainer2/VBoxContainer/MarginContainer/VBoxContainer/HBoxContainer4" unique_id=704837278]
+layout_mode = 2
+mouse_filter = 1
+text = "第三方游戏链接"
+
+[node name="LineEdit" type="LineEdit" parent="MarginContainer/ScrollContainer/VBoxContainer/PanelContainer2/VBoxContainer/MarginContainer/VBoxContainer/HBoxContainer4" unique_id=130899238]
+layout_mode = 2
+size_flags_horizontal = 10
+theme_type_variation = &"SpinBoxInnerLineEdit"
+placeholder_text = "接口格式需与官方保持一致"
+alignment = 2
+expand_to_text_length = true
+clear_button_enabled = true
+
+[node name="Button" type="Button" parent="MarginContainer/ScrollContainer/VBoxContainer/PanelContainer2/VBoxContainer/MarginContainer/VBoxContainer/HBoxContainer4" unique_id=2026033101]
+custom_minimum_size = Vector2(72, 0)
+layout_mode = 2
+text = "检测"
 
 [node name="PanelContainer3" type="PanelContainer" parent="MarginContainer/ScrollContainer/VBoxContainer" unique_id=1108486692]
 material = ExtResource("4_tr7nv")

--- a/MVL/Src/Utils/Config/BaseConfig.cs
+++ b/MVL/Src/Utils/Config/BaseConfig.cs
@@ -23,6 +23,12 @@ public class BaseConfig : BaseConfigV0 {
 	[JsonPropertyOrder(4)]
 	public bool AutoCheckVersion { get; set; } = true;
 
+	[JsonPropertyOrder(2)]
+	public bool UseThirdPartyGameDownload { get; set; } = false;
+
+	[JsonPropertyOrder(2)]
+	public string ThirdPartyGameLink { get; set; } = "";
+
 	public void Save() {
 		lock (_syncLock) {
 			if (string.IsNullOrEmpty(_configPath)) {


### PR DESCRIPTION
1. 新增第三方游戏下载源配置
- 新增 `UseThirdPartyCdn` / `ThirdPartyCdnJsonUrl` 配置项
- 在发布页下载列表中，支持根据设置切换官方/第三方 `stable-unstable.json`

2. 设置页增强
- 文案调整：
  - “第三方CDN” -> “第三方游戏下载”
  - “第三方JSON” -> “第三方游戏链接”
- 新增“检测”按钮，用于校验第三方链接可访问性、 JSON 有效性
- 检测时增加状态反馈

3. 贡献者信息补充
- 在开发人员中新增：`寒士杰克 <https://github.com/TGU-HansJack>`

**修改文件如下**
- `MVL/Src/UI/Page/ReleasePage.cs`
- `MVL/Src/UI/Page/SettingPage.cs`
- `MVL/Src/UI/Page/setting_page.tscn`
- `MVL/Src/Utils/Config/BaseConfig.cs`
- `MVL/Src/Utils/Config/BaseConfigV0.cs`
- `AUTHORS.md`
